### PR TITLE
Browser compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,9 +34,10 @@
     "pretty": "prettier --write src"
   },
   "dependencies": {
+    "assert": "^2.1.0",
+    "axios": "^1.7.9",
     "entities": "^4.5.0",
-    "fast-xml-parser": "^4.3.2",
-    "got": "^11.8.6"
+    "fast-xml-parser": "^4.3.2"
   },
   "devDependencies": {
     "@types/node": "^20.10.5",

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,4 +1,4 @@
-import got from 'got'
+import axios from 'axios'
 
 const url = {
   prod: 'https://wyszukiwarkaregon.stat.gov.pl/wsBIR/UslugaBIRzewnPubl.svc',
@@ -11,14 +11,12 @@ export type QueryOptions = {
 }
 
 export async function query(prod: boolean, options: QueryOptions) {
-  const { headers, ...rest } = options
-  // @ts-ignore
-  const { body } = await got.post(prod ? url.prod : url.test, {
+  const { headers, body } = options
+  const response = await axios.post(prod ? url.prod : url.test, body, {
     headers: {
       'Content-Type': 'application/soap+xml',
       ...headers,
     },
-    ...rest,
   })
-  return body
+  return response.data
 }


### PR DESCRIPTION
Hello. Thanks for the amazing library.


I tried using it in a browser environment (electron renderer process) and noticed that it doesn't work because of 2 problems:
1. `got` library does not work in browsers, it's node-only. 
2. `assert` is a node-only import, but there is a polyfill for the browsers.

I managed to get it running with these two changes:

1. use `axios` instead of `got`
2. add [assert](https://www.npmjs.com/package/assert) polyfill.

I'm providing a merge request with these changes, if you are interested in making your library work in browsers.
